### PR TITLE
Update pulumi-terraform to 08d502e9b4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,8 @@ replace (
 require (
 	github.com/hashicorp/terraform v0.12.0
 	github.com/pkg/errors v0.8.1
-	github.com/pulumi/pulumi v0.17.22-0.20190702185104-ebceea93a5da
-	github.com/pulumi/pulumi-terraform v0.18.4-0.20190709052202-629f7c54269d
+	github.com/pulumi/pulumi v0.17.23-0.20190715212628-02ffff88409f
+	github.com/pulumi/pulumi-terraform v0.18.4-0.20190716112909-08d502e9b427
 	github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709
 	github.com/terraform-providers/terraform-provider-gitlab v0.0.0-20190612175539-be61c1d348ba
 )

--- a/go.sum
+++ b/go.sum
@@ -374,6 +374,8 @@ github.com/masterzen/winrm v0.0.0-20190223112901-5e5c9a7fe54b/go.mod h1:wr1VqkwW
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1 h1:G1f5SKeVxmagw/IyvzvtZE4Gybcc4Tr1tf7I8z0XgOg=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
+github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
+github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
@@ -480,6 +482,8 @@ github.com/pulumi/pulumi v0.17.6-0.20190410045519-ef5e148a73c0 h1:NqGT9rxjyADqq2
 github.com/pulumi/pulumi v0.17.6-0.20190410045519-ef5e148a73c0/go.mod h1:RIy1gmz8Vyy7H5w2ffHJ23aZHCOggF2zk2c+KD1GMtY=
 github.com/pulumi/pulumi v0.17.22-0.20190702185104-ebceea93a5da h1:8j8kMQncrqAfspsfmmjcEQVzeWYDYFHF8O545CcXEG4=
 github.com/pulumi/pulumi v0.17.22-0.20190702185104-ebceea93a5da/go.mod h1:YUZl+EG25I3Zs337/O7gRiGfquphPBOrMG6QZYAWW9g=
+github.com/pulumi/pulumi v0.17.23-0.20190715212628-02ffff88409f h1:3K/cssb6A3pEEDcNPEZSOVF70jPIdgftGX9UcSINZ/0=
+github.com/pulumi/pulumi v0.17.23-0.20190715212628-02ffff88409f/go.mod h1:d+ivoM5WASR34nx+EJwBMfWtuU8oczAY5lMTrXsdboM=
 github.com/pulumi/pulumi-digitalocean v0.18.1 h1:9dPgQg75qKYdsx5zWbNCRnXGl1LesSwZhQjru8ssy0Y=
 github.com/pulumi/pulumi-digitalocean v0.18.1/go.mod h1:leixuMOLoxCA53LaEbDFxHSj0YWQnfoSymrEzc4iQAs=
 github.com/pulumi/pulumi-terraform v0.18.2 h1:87eFAASBmHCH41OlcGZAydGgSYFTIPFoKjzaJ8Edw5M=
@@ -492,6 +496,8 @@ github.com/pulumi/pulumi-terraform v0.18.4-0.20190703150544-a9a9ca8157ca h1:Zj43
 github.com/pulumi/pulumi-terraform v0.18.4-0.20190703150544-a9a9ca8157ca/go.mod h1:5QshR5Q/a3gJiSPx1d+AblvcvfJCYC7255q8DtnvJv4=
 github.com/pulumi/pulumi-terraform v0.18.4-0.20190709052202-629f7c54269d h1:Pmw7a8wXD20fcgekI6U5QiX4IzRFcaj9YSUgE/LMV5s=
 github.com/pulumi/pulumi-terraform v0.18.4-0.20190709052202-629f7c54269d/go.mod h1:5QshR5Q/a3gJiSPx1d+AblvcvfJCYC7255q8DtnvJv4=
+github.com/pulumi/pulumi-terraform v0.18.4-0.20190716112909-08d502e9b427 h1:zCNael1dbtaWcWWXdoxChRaFaXeKDu2F4dycNr/rT5A=
+github.com/pulumi/pulumi-terraform v0.18.4-0.20190716112909-08d502e9b427/go.mod h1:HZZfntNPhurepaYfYpimuN4KGSuEJm6/EUOopwS8oUM=
 github.com/pulumi/scripts v0.0.0-20190410070955-3e8f41455b9c/go.mod h1:ZEj/wbB9HtXA9U6xWWpe9U+7vuDpiTIIt7Gca/XpfsA=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/reconquest/loreley v0.0.0-20160708080500-2ab6b7470a54 h1:J2RvHxEMIzMV6XbaZIj9s5G4lG3hhqWxS7Cl1Jii44c=

--- a/sdk/go/gitlab/_about.go
+++ b/sdk/go/gitlab/_about.go
@@ -1,0 +1,8 @@
+//nolint: lll
+// Package gitlab exports types, functions, subpackages for provisioning gitlab resources.
+//
+// > This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-gitlab)
+// > distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,
+// > first check the [`pulumi/pulumi-gitlab` repo](https://github.com/pulumi/pulumi-gitlab/issues); however, if that doesn't turn up anything,
+// > please consult the source [`terraform-providers/terraform-provider-gitlab` repo](https://github.com/terraform-providers/terraform-provider-gitlab/issues).
+package gitlab

--- a/sdk/go/gitlab/config/_about.go
+++ b/sdk/go/gitlab/config/_about.go
@@ -1,0 +1,8 @@
+//nolint: lll
+// Package config exports types, functions, subpackages for provisioning config resources.
+//
+// > This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-gitlab)
+// > distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,
+// > first check the [`pulumi/pulumi-gitlab` repo](https://github.com/pulumi/pulumi-gitlab/issues); however, if that doesn't turn up anything,
+// > please consult the source [`terraform-providers/terraform-provider-gitlab` repo](https://github.com/terraform-providers/terraform-provider-gitlab/issues).
+package config

--- a/sdk/go/gitlab/group.go
+++ b/sdk/go/gitlab/group.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// > This content is derived from https://github.com/terraform-providers/terraform-provider-gitlab/blob/master/website/docs/r/group.html.markdown.
 type Group struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gitlab/project.go
+++ b/sdk/go/gitlab/project.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// > This content is derived from https://github.com/terraform-providers/terraform-provider-gitlab/blob/master/website/docs/r/project.html.markdown.
 type Project struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gitlab/user.go
+++ b/sdk/go/gitlab/user.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// > This content is derived from https://github.com/terraform-providers/terraform-provider-gitlab/blob/master/website/docs/r/user.html.markdown.
 type User struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/nodejs/group.ts
+++ b/sdk/nodejs/group.ts
@@ -4,6 +4,9 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
+/**
+ * > This content is derived from https://github.com/terraform-providers/terraform-provider-gitlab/blob/master/website/docs/r/group.html.markdown.
+ */
 export class Group extends pulumi.CustomResource {
     /**
      * Get an existing Group resource's state with the given name, ID, and optional extra

--- a/sdk/nodejs/project.ts
+++ b/sdk/nodejs/project.ts
@@ -4,6 +4,9 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
+/**
+ * > This content is derived from https://github.com/terraform-providers/terraform-provider-gitlab/blob/master/website/docs/r/project.html.markdown.
+ */
 export class Project extends pulumi.CustomResource {
     /**
      * Get an existing Project resource's state with the given name, ID, and optional extra

--- a/sdk/nodejs/user.ts
+++ b/sdk/nodejs/user.ts
@@ -4,6 +4,9 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
+/**
+ * > This content is derived from https://github.com/terraform-providers/terraform-provider-gitlab/blob/master/website/docs/r/user.html.markdown.
+ */
 export class User extends pulumi.CustomResource {
     /**
      * Get an existing User resource's state with the given name, ID, and optional extra


### PR DESCRIPTION
This PR updates `pulumi-terraform` to [08d502e9b4](https://github.com/pulumi/pulumi-terraform/commit/08d502e9b427397307d268c0d0343499452717a9), and re-runs code generation