### PR TITLE
Update Goreleaser and deprecate CHANGELOG

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,7 +28,8 @@ builds:
   - -X github.com/pulumi/pulumi-gitlab/provider/v4/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-gitlab/
 changelog:
-  skip: true
+  use: git
+  sort: asc
 release:
   disable: false
 snapshot:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## HEAD (Unreleased)
 _(none)_
 
+## Notice (2022-01-06)
+
+*As of this notice, using CHANGELOG.md is DEPRECATED. We will be using [GitHub Releases](https://github.com/pulumi/pulumi-gitlab/releases) for this repository*
+
 ---
 
 ## 4.4.0 (2021-11-30)


### PR DESCRIPTION
Part of https://github.com/pulumi/release-bot/issues/13