### PR TITLE
Make build.gradle compatible with Gradle 8

### DIFF
--- a/sdk/java/build.gradle
+++ b/sdk/java/build.gradle
@@ -48,12 +48,12 @@ dependencies {
 
 task sourcesJar(type: Jar) {
     from sourceSets.main.allJava
-    classifier = 'sources'
+    archiveClassifier = 'sources'
 }
 
 task javadocJar(type: Jar) {
     from javadoc
-    classifier = 'javadoc'
+    archiveClassifier = 'javadoc'
 }
 
 def genPulumiResources = tasks.register('genPulumiResources') {


### PR DESCRIPTION
There are two Jar tasks in the build file using options that Gradle 8 has deprecated. This patch updates them to make it compatible with the new version.