### PR TITLE
Fix gitlab token use

### DIFF
--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -5,7 +5,6 @@ env:
     6.0.x
     3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
   GOVERSION: 1.20.1
   JAVAVERSION: "11"
   NODEVERSION: 16.x
@@ -17,6 +16,7 @@ env:
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_API: https://api.pulumi-staging.io
+  PULUMI_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,6 @@ env:
     6.0.x
     3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
   GOVERSION: 1.20.1
   JAVAVERSION: "11"
   NODEVERSION: 16.x
@@ -17,6 +16,7 @@ env:
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_API: https://api.pulumi-staging.io
+  PULUMI_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -5,7 +5,6 @@ env:
     6.0.x
     3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
   GOVERSION: 1.20.1
   JAVAVERSION: "11"
   NODEVERSION: 16.x
@@ -17,6 +16,7 @@ env:
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_API: https://api.pulumi-staging.io
+  PULUMI_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -17,6 +17,7 @@ env:
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_API: https://api.pulumi-staging.io
+  PULUMI_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,7 +5,6 @@ env:
     6.0.x
     3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
   GOVERSION: 1.20.1
   JAVAVERSION: "11"
   NODEVERSION: 16.x
@@ -17,6 +16,7 @@ env:
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_API: https://api.pulumi-staging.io
+  PULUMI_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ env:
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_API: https://api.pulumi-staging.io
+  PULUMI_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/resync-build.yml
+++ b/.github/workflows/resync-build.yml
@@ -5,7 +5,6 @@ env:
     6.0.x
     3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
   GOVERSION: 1.20.1
   JAVAVERSION: "11"
   NODEVERSION: 16.x
@@ -18,6 +17,7 @@ env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_EXTRA_MAPPING_ERROR: true
+  PULUMI_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PULUMI_MISSING_MAPPING_ERROR: true

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -5,7 +5,6 @@ env:
     6.0.x
     3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
   GOVERSION: 1.20.1
   JAVAVERSION: "11"
   NODEVERSION: 16.x
@@ -18,6 +17,7 @@ env:
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_API: https://api.pulumi-staging.io
+  PULUMI_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/examples/examples_dotnet_test.go
+++ b/examples/examples_dotnet_test.go
@@ -1,4 +1,5 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+//go:build dotnet || all
 // +build dotnet all
 
 package examples
@@ -10,7 +11,7 @@ import (
 )
 
 func getCsharpBaseOptions(t *testing.T) integration.ProgramTestOptions {
-	base := getBaseOptions()
+	base := getBaseOptions(t)
 	baseCsharp := base.With(integration.ProgramTestOptions{
 		Dependencies: []string{
 			"Pulumi.SpotInst",

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -9,6 +9,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//go:build nodejs || all
 // +build nodejs all
 
 package examples
@@ -30,8 +31,7 @@ func TestAccProject(t *testing.T) {
 }
 
 func getJSBaseOptions(t *testing.T) integration.ProgramTestOptions {
-	checkTestCredentials(t)
-	base := getBaseOptions()
+	base := getBaseOptions(t)
 	baseJS := base.With(integration.ProgramTestOptions{
 		Dependencies: []string{
 			"@pulumi/gitlab",

--- a/examples/examples_py_test.go
+++ b/examples/examples_py_test.go
@@ -1,4 +1,5 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+//go:build nodejs || all
 // +build nodejs all
 
 package examples
@@ -11,7 +12,7 @@ import (
 )
 
 func getPythonBaseOptions(t *testing.T) integration.ProgramTestOptions {
-	base := getBaseOptions()
+	base := getBaseOptions(t)
 	basePython := base.With(integration.ProgramTestOptions{
 		Dependencies: []string{
 			filepath.Join("..", "sdk", "python", "bin"),

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -20,9 +20,9 @@ import (
 )
 
 func checkTestCredentials(t *testing.T) {
-	token := os.Getenv("GITLAB_TOKEN")
+	token := os.Getenv("PULUMI_GITLAB_TOKEN")
 	if token == "" {
-		t.Skipf("Skipping test due to missing GITLAB_TOKEN environment variable")
+		t.Skipf("Skipping test due to missing PULUMI_GITLAB_TOKEN environment variable")
 	}
 }
 

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -13,18 +13,12 @@
 package examples
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 )
-
-func checkTestCredentials(t *testing.T) {
-	token := os.Getenv("PULUMI_GITLAB_TOKEN")
-	if token == "" {
-		t.Skipf("Skipping test due to missing PULUMI_GITLAB_TOKEN environment variable")
-	}
-}
 
 func getCwd(t *testing.T) string {
 	cwd, err := os.Getwd()
@@ -35,8 +29,13 @@ func getCwd(t *testing.T) string {
 	return cwd
 }
 
-func getBaseOptions() integration.ProgramTestOptions {
+func getBaseOptions(t *testing.T) integration.ProgramTestOptions {
+	token := os.Getenv("PULUMI_GITLAB_TOKEN")
+	if token == "" {
+		t.Skipf("Skipping test due to missing PULUMI_GITLAB_TOKEN environment variable")
+	}
 	return integration.ProgramTestOptions{
 		ExpectRefreshChanges: true,
+		Env:                  []string{fmt.Sprintf("GITLAB_TOKEN=%s", token)},
 	}
 }


### PR DESCRIPTION
The use of GITLAB_TOKEN variable for tests was confusing the publish action. Try using PULUMI_GITLAB_TOKEN instead.