### PR TITLE
Update import path for go to v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NPM version](https://badge.fury.io/js/%40pulumi%2Fgitlab.svg)](https://www.npmjs.com/package/@pulumi/gitlab)
 [![Python version](https://badge.fury.io/py/pulumi-gitlab.svg)](https://pypi.org/project/pulumi-gitlab)
 [![NuGet version](https://badge.fury.io/nu/pulumi.gitlab.svg)](https://badge.fury.io/nu/pulumi.gitlab)
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/pulumi/pulumi-gitlab/sdk/v4/go)](https://pkg.go.dev/github.com/pulumi/pulumi-gitlab/sdk/v6/go)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/pulumi/pulumi-gitlab/sdk/v6/go)](https://pkg.go.dev/github.com/pulumi/pulumi-gitlab/sdk/v6/go)
 [![License](https://img.shields.io/npm/l/%40pulumi%2Fpulumi.svg)](https://github.com/pulumi/pulumi-gitlab/blob/master/LICENSE)
 
 # GitLab provider

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/pulumi-gitlab/sdk/v4
+module github.com/pulumi/pulumi-gitlab/sdk/v6
 
 go 1.19
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -3,7 +3,7 @@
 [![NPM version](https://badge.fury.io/js/%40pulumi%2Fgitlab.svg)](https://www.npmjs.com/package/@pulumi/gitlab)
 [![Python version](https://badge.fury.io/py/pulumi-gitlab.svg)](https://pypi.org/project/pulumi-gitlab)
 [![NuGet version](https://badge.fury.io/nu/pulumi.gitlab.svg)](https://badge.fury.io/nu/pulumi.gitlab)
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/pulumi/pulumi-gitlab/sdk/v4/go)](https://pkg.go.dev/github.com/pulumi/pulumi-gitlab/sdk/v6/go)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/pulumi/pulumi-gitlab/sdk/v6/go)](https://pkg.go.dev/github.com/pulumi/pulumi-gitlab/sdk/v6/go)
 [![License](https://img.shields.io/npm/l/%40pulumi%2Fpulumi.svg)](https://github.com/pulumi/pulumi-gitlab/blob/master/LICENSE)
 
 # GitLab provider


### PR DESCRIPTION
Fixes #294
This was missed in the most recent major upgrade 😞 