### PR TITLE
Use PULUMI_GITLAB_TOKEN to avoid goreleaser issue

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -2,8 +2,7 @@ provider: gitlab
 major-version: 6
 upstreamProviderOrg: gitlabhq
 env:
-  PULUMI_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
-  GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+  PULUMI_GITLAB_TOKEN: ${{ secrets.PULUMI_GITLAB_TOKEN }}
 makeTemplate: bridged
 team: ecosystem
 plugins:

--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -6,7 +6,6 @@ env:
       6.0.x
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
   GOVERSION: 1.21.x
   GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
@@ -18,7 +17,7 @@ env:
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_API: https://api.pulumi-staging.io
-  PULUMI_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+  PULUMI_GITLAB_TOKEN: ${{ secrets.PULUMI_GITLAB_TOKEN }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -12,7 +12,6 @@ env:
       6.0.x
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
   GOVERSION: 1.21.x
   GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
@@ -24,7 +23,7 @@ env:
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_API: https://api.pulumi-staging.io
-  PULUMI_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+  PULUMI_GITLAB_TOKEN: ${{ secrets.PULUMI_GITLAB_TOKEN }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,6 @@ env:
       6.0.x
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
   GOVERSION: 1.21.x
   GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
@@ -23,7 +22,7 @@ env:
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_API: https://api.pulumi-staging.io
-  PULUMI_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+  PULUMI_GITLAB_TOKEN: ${{ secrets.PULUMI_GITLAB_TOKEN }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -6,7 +6,6 @@ env:
       6.0.x
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
   GOVERSION: 1.21.x
   GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
@@ -18,7 +17,7 @@ env:
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_API: https://api.pulumi-staging.io
-  PULUMI_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+  PULUMI_GITLAB_TOKEN: ${{ secrets.PULUMI_GITLAB_TOKEN }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -7,7 +7,6 @@ env:
       6.0.x
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
   GOVERSION: 1.21.x
   GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
@@ -19,7 +18,7 @@ env:
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_API: https://api.pulumi-staging.io
-  PULUMI_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+  PULUMI_GITLAB_TOKEN: ${{ secrets.PULUMI_GITLAB_TOKEN }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,7 +6,6 @@ env:
       6.0.x
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
   GOVERSION: 1.21.x
   GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
@@ -18,7 +17,7 @@ env:
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_API: https://api.pulumi-staging.io
-  PULUMI_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+  PULUMI_GITLAB_TOKEN: ${{ secrets.PULUMI_GITLAB_TOKEN }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ env:
       6.0.x
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
   GOVERSION: 1.21.x
   GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
@@ -18,7 +17,7 @@ env:
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_API: https://api.pulumi-staging.io
-  PULUMI_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+  PULUMI_GITLAB_TOKEN: ${{ secrets.PULUMI_GITLAB_TOKEN }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/resync-build.yml
+++ b/.github/workflows/resync-build.yml
@@ -8,7 +8,6 @@ env:
       6.0.x
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
   GOVERSION: 1.21.x
   GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
@@ -20,7 +19,7 @@ env:
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_API: https://api.pulumi-staging.io
-  PULUMI_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+  PULUMI_GITLAB_TOKEN: ${{ secrets.PULUMI_GITLAB_TOKEN }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -7,7 +7,6 @@ env:
       6.0.x
       3.1.301
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
   GOVERSION: 1.21.x
   GRADLEVERSION: "7.6"
   JAVAVERSION: "11"
@@ -19,7 +18,7 @@ env:
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_API: https://api.pulumi-staging.io
-  PULUMI_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+  PULUMI_GITLAB_TOKEN: ${{ secrets.PULUMI_GITLAB_TOKEN }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/provider/provider_program_test.go
+++ b/provider/provider_program_test.go
@@ -119,9 +119,7 @@ func TestPrograms(t *testing.T) {
 func TestProgramsUpgrade(t *testing.T) {
 	for _, p := range programs {
 		t.Run(p, func(t *testing.T) {
-			testProviderUpgrade(t, p, WithConfig(map[string]string{
-				"gitlab:token": os.Getenv("PULUMI_GITLAB_TOKEN"),
-			}))
+			testProviderUpgrade(t, p)
 		})
 	}
 }

--- a/provider/provider_program_test.go
+++ b/provider/provider_program_test.go
@@ -81,6 +81,7 @@ func testProviderUpgradeWithOpts(
 	test := pulumitest.NewPulumiTest(t, dir,
 		opttest.DownloadProviderVersion(providerName, baselineVersion),
 		opttest.LocalProviderPath(providerName, filepath.Join(cwd, "..", "bin")),
+		opttest.Env("GITLAB_TOKEN", os.Getenv("PULUMI_GITLAB_TOKEN")),
 	)
 	for k, v := range config {
 		test.SetConfig(k, v)
@@ -102,6 +103,7 @@ func testProgram(t *testing.T, dir string) {
 	test := pulumitest.NewPulumiTest(t, dir,
 		opttest.LocalProviderPath(providerName, filepath.Join(cwd, "..", "bin")),
 		opttest.SkipInstall(),
+		opttest.Env("GITLAB_TOKEN", os.Getenv("PULUMI_GITLAB_TOKEN")),
 	)
 	test.Up()
 }
@@ -117,7 +119,9 @@ func TestPrograms(t *testing.T) {
 func TestProgramsUpgrade(t *testing.T) {
 	for _, p := range programs {
 		t.Run(p, func(t *testing.T) {
-			testProviderUpgrade(t, p)
+			testProviderUpgrade(t, p, WithConfig(map[string]string{
+				"gitlab:token": os.Getenv("PULUMI_GITLAB_TOKEN"),
+			}))
 		})
 	}
 }


### PR DESCRIPTION
Fix for #561, #562.

Due to Goreleaser finding multiple git client default tokens, we need to set our gitlab token to a nonstandard name.
Adjustments to providertest were made to reflect this.
