### PR TITLE
Remove `make upstream` from `preTest`

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -18,9 +18,6 @@ plugins:
 
 actions:
   preTest:
-    - name: make upstream
-      run: |
-        make upstream
     - name: Run provider tests
       run: |
         cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -132,6 +132,9 @@ jobs:
       - prerequisites
       - build_provider
       - build_sdk
+    permissions:
+      contents: read
+      id-token: write
     secrets: inherit
     with:
       version: ${{ needs.prerequisites.outputs.version }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -73,6 +73,9 @@ jobs:
       - prerequisites
       - build_provider
       - build_sdk
+    permissions:
+      contents: read
+      id-token: write
     secrets: inherit
     with:
       version: ${{ needs.prerequisites.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,9 @@ jobs:
       - prerequisites
       - build_provider
       - build_sdk
+    permissions:
+      contents: read
+      id-token: write
     secrets: inherit
     with:
       version: ${{ needs.prerequisites.outputs.version }}

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -122,6 +122,9 @@ jobs:
       - prerequisites
       - build_provider
       - build_sdk
+    permissions:
+      contents: read
+      id-token: write
     secrets: inherit
     with:
       version: ${{ needs.prerequisites.outputs.version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,9 +78,6 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         version: v2.5.0
-    - name: make upstream
-      run: |
-        make upstream
     - name: Run provider tests
       run: |
         cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt


### PR DESCRIPTION
After https://github.com/pulumi/ci-mgmt/pull/1151 our `make` targets should now all correctly call `make upstream` if they need it.

This updates `.ci-mgmt.yaml` and re-runs `make ci-mgmt`.