### PR TITLE
Remove unused npm dependencies

### DIFF
--- a/provider/cmd/pulumi-resource-gitlab/schema.json
+++ b/provider/cmd/pulumi-resource-gitlab/schema.json
@@ -32,11 +32,6 @@
         "nodejs": {
             "packageDescription": "A Pulumi package for creating and managing GitLab resources.",
             "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/gitlabhq/terraform-provider-gitlab)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-gitlab` repo](https://github.com/pulumi/pulumi-gitlab/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-gitlab` repo](https://github.com/gitlabhq/terraform-provider-gitlab/issues).",
-            "dependencies": {
-                "builtin-modules": "3.0.0",
-                "read-package-tree": "^5.2.1",
-                "resolve": "^1.7.1"
-            },
             "devDependencies": {
                 "@types/node": "^10.0.0"
             },

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -92,11 +92,6 @@ func Provider() tfbridge.ProviderInfo {
 			"gitlab_user_gpgkey": {Tok: gitLabResource("UserGpgKey")},
 		},
 		JavaScript: &tfbridge.JavaScriptInfo{
-			Dependencies: map[string]string{
-				"builtin-modules":   "3.0.0",
-				"read-package-tree": "^5.2.1",
-				"resolve":           "^1.7.1",
-			},
 			DevDependencies: map[string]string{
 				"@types/node": "^10.0.0", // so we can access strongly typed node definitions.
 			},

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -13,10 +13,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.142.0",
-        "builtin-modules": "3.0.0",
-        "read-package-tree": "^5.2.1",
-        "resolve": "^1.7.1"
+        "@pulumi/pulumi": "^3.142.0"
     },
     "devDependencies": {
         "@types/node": "^10.0.0",


### PR DESCRIPTION
It looks like these dependencies aren't actually used anywhere, so stop depending on them.

The motivation for this change is that the dependency on `resolve` causes errors to be logged in logs during plugin discovery, because the package includes tests that have malformed `package.json` files. If we don't actually need the dependency it'd be nice to remove it so those errors are no longer logged (so users don't [ask us about them](https://github.com/pulumi/pulumi/issues/17578)).

Also remove `read-package-tree` since it is deprecated.

Also remove `builtin-modules`, since it doesn't appear to be used either.

Similar to https://github.com/pulumi/pulumi-aws/pull/3238 and https://github.com/pulumi/pulumi-aws/pull/4971
Reference: https://github.com/pulumi/pulumi/issues/17578