### PR TITLE
Remove golangci-lint override, defer to .config/mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,4 @@
 [tools]
-golangci-lint = "2.7.0"
 "vfox-pulumi:pulumi/pulumi-std" = "2.2.0"
 "vfox-pulumi:pulumi/pulumi-converter-terraform" = "1.2.4"
 "vfox-pulumi:pulumi/pulumi-local" = "0.1.6"


### PR DESCRIPTION
Removes the `golangci-lint` pin from the local `mise.toml`.

The local override was set to `2.7.0` (built with Go 1.25), which takes precedence over `.config/mise.toml` managed by ci-mgmt. When the project's Go version moved to 1.26.1, lint broke:
```
can't load config: the Go language version (go1.25) used to build golangci-lint is lower than the targeted Go version (1.26.1)
```

Removing the override means `.config/mise.toml` (currently pinned to `2.9.0` by ci-mgmt) takes effect automatically, and future ci-mgmt bumps propagate without needing a manual override update.

Fixes pulumi/pulumi-gitlab#1172
